### PR TITLE
Various text rendering improvements

### DIFF
--- a/src/bitmap/AbstractBitmap.hx
+++ b/src/bitmap/AbstractBitmap.hx
@@ -124,6 +124,23 @@ import bitmap.transformation.*;
 		}
 	}
 
+	/**
+		Copies a region of the bitmap `b`, respecting transparency information in `b`
+		@see copyFrom() - plain copy
+	**/
+	public function insertWithTransparency(b:Bitmap, bCoords:Types.Point, regionThis:Types.Rectangle):Void {
+		// TODO: check bounds
+		for (y in 0...regionThis.height) {
+			for (x in 0...regionThis.width) {
+				var thisColor = get(regionThis.x + x, regionThis.y + y);
+				set(
+					regionThis.x + x, regionThis.y + y,
+					thisColor.blendWithAlpha(b.get(bCoords.x + x, bCoords.y + y))
+				);
+			}
+		}
+	}
+
 	public function compare(b:Bitmap, ?regionB:Types.Rectangle, ?thisRegion:Types.Rectangle):Float {
 		return BitmapUtil.compare(this, b, regionB, thisRegion);
 	}

--- a/src/bitmap/Bitmap.hx
+++ b/src/bitmap/Bitmap.hx
@@ -86,12 +86,17 @@ import bitmap.transformation.*;
 
 	/**
 	 * Writes in this bitmap given region of given bitmap, or if no region is given, the bitmap entirely.
-	**/
- public function copyFrom(b:Bitmap, bCoords:Types.Point, regionThis:Types.Rectangle):Void;
+	 **/
+	public function copyFrom(b:Bitmap, bCoords:Types.Point, regionThis:Types.Rectangle):Void;
 	// public function copyFrom(b:Bitmap, ?region:Types.Rectangle, ?thisRegion:Types.Rectangle):Void;
+	/**
+		Copies a region of the bitmap `b`, respecting transparency information in `b`
+		@see copyFrom() - plain copy
+	**/
+	public function insertWithTransparency(b:Bitmap, bCoords:Types.Point, regionThis:Types.Rectangle):Void;
 	public function fill(?bg:Color):Void;
 	// public function copy(?r:Types.Rectangle):Bitmap;
-  public function copy(r:Types.Rectangle):Bitmap ;
+	public function copy(r:Types.Rectangle):Bitmap ;
 	public function compare(b:Bitmap, ?regionA:Types.Rectangle, ?thisRegion:Types.Rectangle):Float;
 	public function bounds():Types.Rectangle;
 }

--- a/src/bitmap/Color.hx
+++ b/src/bitmap/Color.hx
@@ -103,4 +103,19 @@ package bitmap;
 		this = (r << 24) | (g << 16) | (b << 8) | value;
 		return value;
 	}
+
+	// won't be needed when Haxe 4.3.0 makes it into widespread usage
+	private var self(get, never): Color;
+	private function get_self(): Color return this;
+
+	// see https://en.wikipedia.org/wiki/Alpha_compositing
+	public function blendWithAlpha(other: Color): Color {
+		var alphaCorrected = (self.a/255) * (1 - other.a/255);
+		var resultAlpha = other.a/255 + alphaCorrected;
+		var resultR = (other.r * other.a/255 + self.r * alphaCorrected) / resultAlpha;
+		var resultG = (other.g * other.a/255 + self.g * alphaCorrected) / resultAlpha;
+		var resultB = (other.b * other.a/255 + self.b * alphaCorrected) / resultAlpha;
+
+		return Color.create(Std.int(resultR), Std.int(resultG), Std.int(resultB), Std.int(resultAlpha*255));
+	}
 }

--- a/src/bitmap/text/Font.hx
+++ b/src/bitmap/text/Font.hx
@@ -6,7 +6,7 @@ import bitmap.text.FontManager.*;
 class Font {
 	private var glyps:Map<Int, Glyph>;
 	private var bitmap:Bitmap;
- var fontFamiliy:String;
+	public var fontFamiliy:String;
 	public function new(fontFamiliy_:String, glyps_:Map<Int, Glyph> , img:Bitmap) {
 		glyps = glyps_;
 		bitmap = img;

--- a/src/bitmap/text/FontManager.hx
+++ b/src/bitmap/text/FontManager.hx
@@ -91,9 +91,8 @@ class FontManager {
 	/**
 		Returns the width the text will take up when rendered
 	**/
-	public function getWidth(o: RenderTextOptions): Int {
-		return renderer.getWidth(o.combine({
-			font: getFont(o.fontFamily),
-		}));
+	public function getWidth(fontFamily: String, text: String, throwOnGlyphNotFound: Bool = false): Int {
+		return renderer.getWidth(getFont(fontFamily), text, throwOnGlyphNotFound);
 	}
 }
+

--- a/src/bitmap/text/FontManager.hx
+++ b/src/bitmap/text/FontManager.hx
@@ -87,4 +87,13 @@ class FontManager {
 		});
 		return renderer.render(o2);
 	}
+
+	/**
+		Returns the width the text will take up when rendered
+	**/
+	public function getWidth(o: RenderTextOptions): Int {
+		return renderer.getWidth(o.combine({
+			font: getFont(o.fontFamily),
+		}));
+	}
 }

--- a/src/bitmap/text/Renderer.hx
+++ b/src/bitmap/text/Renderer.hx
@@ -45,13 +45,13 @@ class Renderer {
 	/**
 		Returns the width the text will take up when rendered
 	**/
-	public function getWidth(o: RenderOptions) {
-		return o.text.split('').fold(
+	public function getWidth(font: Font, text: String, throwOnGlyphNotFound: Bool) {
+		return text.split('').fold(
 			(item, carry) -> {
-				var glyph = o.font.getGlyphByString(item);
+				var glyph = font.getGlyphByString(item);
 				return if (glyph == null)
-					if (o.throwOnGlyphNotFound)
-						throw 'Glyph not found for font ${o.fontFamily} and character ${item}'
+					if (throwOnGlyphNotFound)
+						throw 'Glyph not found for font ${font.fontFamiliy} and character ${item}'
 					else
 						carry
 				else

--- a/src/bitmap/text/Renderer.hx
+++ b/src/bitmap/text/Renderer.hx
@@ -26,7 +26,7 @@ class Renderer {
 				throw 'Glyph not found for font ${o.fontFamily} and character ${a[i]}';
 			}
 			// TODO: check region, add new lines verify end of bitmap horizotal and certical, Impement align, justify and word wrap.
-			output.copyFrom(glyph.bitmap, {x: 0, y: 0}, {
+			output.insertWithTransparency(glyph.bitmap, {x: 0, y: 0}, {
 				x: x,
 				y: y,
 				width: glyph.width,

--- a/src/bitmap/text/Renderer.hx
+++ b/src/bitmap/text/Renderer.hx
@@ -23,9 +23,13 @@ class Renderer {
 		var a = o.text.split('');
 		for (i in 0...a.length) {
 			var glyph = o.font.getGlyphByString(a[i]);
-			if (glyph != null && o.throwOnGlyphNotFound) {
-				throw 'Glyph not found for font ${o.fontFamily} and character ${a[i]}';
+			if (glyph == null) {
+				if (o.throwOnGlyphNotFound)
+					throw 'Glyph not found for font ${o.fontFamily} and character ${a[i]}'
+				else
+					continue;
 			}
+
 			// TODO: check region, add new lines verify end of bitmap horizotal and certical, Impement align, justify and word wrap.
 			output.insertWithTransparency(glyph.bitmap, {x: 0, y: 0}, {
 				x: x + glyph.xoffset,

--- a/src/bitmap/text/Renderer.hx
+++ b/src/bitmap/text/Renderer.hx
@@ -3,6 +3,8 @@ package bitmap.text;
 import bitmap.text.Types.RenderOptions;
 import bitmap.text.*;
 
+using Lambda;
+
 class Renderer {
 	var glyphs:Map<String, Map<Int, Bitmap>>;
 	var manager:FontManager;
@@ -13,7 +15,6 @@ class Renderer {
 	}
 
 	public function render(o:RenderOptions) {
-		var font = manager.getFont(o.fontFamily);
 		var output = o.output == null ? o.bitmap.clone() : o.output;
 
 		// TODO dictionary for glyphs - extract only  one time
@@ -34,6 +35,25 @@ class Renderer {
 			});
 			x += glyph.xadvance;
 		}
-    return {bitmap: output};
+		return {bitmap: output};
+	}
+
+	/**
+		Returns the width the text will take up when rendered
+	**/
+	public function getWidth(o: RenderOptions) {
+		return o.text.split('').fold(
+			(item, carry) -> {
+				var glyph = o.font.getGlyphByString(item);
+				return if (glyph == null)
+					if (o.throwOnGlyphNotFound)
+						throw 'Glyph not found for font ${o.fontFamily} and character ${item}'
+					else
+						carry
+				else
+					carry + glyph.xadvance;
+			},
+			0
+		);
 	}
 }

--- a/src/bitmap/text/Renderer.hx
+++ b/src/bitmap/text/Renderer.hx
@@ -27,12 +27,12 @@ class Renderer {
 			}
 			// TODO: check region, add new lines verify end of bitmap horizotal and certical, Impement align, justify and word wrap.
 			output.insertWithTransparency(glyph.bitmap, {x: 0, y: 0}, {
-				x: x,
-				y: y,
+				x: x + glyph.xoffset,
+				y: y + glyph.yoffset,
 				width: glyph.width,
-				height: glyph.height
+				height: glyph.height,
 			});
-			x += glyph.width;
+			x += glyph.xadvance;
 		}
     return {bitmap: output};
 	}

--- a/test/FontTest.hx
+++ b/test/FontTest.hx
@@ -6,13 +6,18 @@ import bitmap.Types.Blend;
 class FontTest implements utest.ITest {
 	public function new() {}
 
-	public function testRegisterFont() {
-		var manager = FontManager.getInstance();
-		var font = manager.registerFont({
+	public function setupClass() {
+		// register font
+		FontManager.getInstance().registerFont({
 			img: IOUtil.readFile("test/assets/openSans.png"),
 			fmt: IOUtil.readFile("test/assets/openSans.xml"),
 			fontFamily: 'openSans'
 		});
+	}
+
+	public function testRegisterFont() {
+		var manager = FontManager.getInstance();
+		var font = manager.getFont('openSans');
 		Assert.same([425, 81], [font.getGlyph(124).y, font.getGlyph(124).bitmap.height]);
 		var r = manager.render({
 			text: 'hello world',
@@ -22,5 +27,33 @@ class FontTest implements utest.ITest {
 			bitmap: PNGBitmap.create(IOUtil.readFile("test/assets/bluebells.png"))
 		});
 		BitmapIO.writeBitmap('test/assets/tmpFont1.png', r.bitmap);
+	}
+
+	public function testThrowOnGlyphNotFound() {
+		var manager = FontManager.getInstance();
+		
+		// test that the exception is thrown when it should be
+		Assert.raises(() -> {
+				manager.render({
+					text: 'ř',
+					fontFamily: 'openSans',
+					x: 10,
+					y: 20,
+					bitmap: PNGBitmap.create(IOUtil.readFile("test/assets/bluebells.png")),
+					throwOnGlyphNotFound: true,
+				});
+			},
+			String
+		);
+
+		// test that the exception isn't thrown when it shouldn't be
+		manager.render({
+			text: 'ř',
+			fontFamily: 'openSans',
+			x: 10,
+			y: 20,
+			bitmap: PNGBitmap.create(IOUtil.readFile("test/assets/bluebells.png")),
+			throwOnGlyphNotFound: false,
+		});
 	}
 }


### PR DESCRIPTION
 - Use metrics from the font's XML correctly, making the text actually render in-line
 - Properly blend colors when using a font with transparent background
 - Add a function for precomputing the width a text will take up when rendered
 - Fix an error when a glyph isn't found